### PR TITLE
Pass reference_filename to pysam so CRAM reads decode reliably

### DIFF
--- a/ATARVA/baseline.py
+++ b/ATARVA/baseline.py
@@ -130,9 +130,11 @@ def cooper(bam_file, tbx_file, ref_file, aln_format, contigs, mapq_threshold, ou
         log_name = f'{hid_outfile}_debug_{tidx}.log'
     
     tbx  = pysam.Tabixfile(tbx_file)
-    bam  = pysam.AlignmentFile(bam_file, aln_format)
+    # Pass the reference so pysam can decode CRAM reads; without it htslib falls back to the CRAM header's reference
+    # URL (or the REF_PATH/REF_CACHE), which is unreliable and can silently fail. Ignored for BAM/SAM input.
+    bam  = pysam.AlignmentFile(bam_file, aln_format, reference_filename=ref_file)
     ref  = pysam.FastaFile(ref_file)
-    
+
     # Open the output file
     out = open(out_filename, 'w')
     
@@ -488,7 +490,9 @@ def mini_cooper(bam_file, tbx_file, ref_file, aln_format, contigs, mapq_threshol
     # this function iterates through each contig and processes the genotypes for each locus
     tbx  = pysam.Tabixfile(tbx_file)
     tbx2  = pysam.Tabixfile(tbx_file)
-    bam  = pysam.AlignmentFile(bam_file, aln_format)
+    # Pass the reference so pysam can decode CRAM reads; without it htslib falls back to the CRAM header's reference
+    # URL (or the REF_PATH/REF_CACHE), which is unreliable and can silently fail. Ignored for BAM/SAM input.
+    bam  = pysam.AlignmentFile(bam_file, aln_format, reference_filename=ref_file)
     ref  = pysam.FastaFile(ref_file)
 
 

--- a/ATARVA/genotype.py
+++ b/ATARVA/genotype.py
@@ -269,7 +269,9 @@ def genotype_run(args):
         print(f"Processing sample {each_bam.split('/')[-1]}\n")
 
         count = 0
-        aln_file = pysam.AlignmentFile(each_bam, aln_format)
+        # Pass the reference so pysam can decode CRAM reads in the tag-detection loop below; without it htslib falls
+        # back to the CRAM header's reference URL (or the REF_PATH/REF_CACHE), which is unreliable. Ignored for BAM/SAM.
+        aln_file = pysam.AlignmentFile(each_bam, aln_format, reference_filename=args.fasta)
         length = 0
         for read in aln_file.fetch():
             if (read.flag & 0X400) or (read.flag & 0X100): continue 


### PR DESCRIPTION
### Problem

When genotyping CRAM input, ATaRVa opens the alignment file with `pysam.AlignmentFile(path, 'rc')` without passing a reference. In that case htslib decodes the CRAM against the reference recorded in the CRAM header (the `UR:`/`M5:` `@SQ` tags) or the `REF_PATH`/`REF_CACHE` cache. When that reference is unreachable (a stale local path, or no network/cache for the md5-based EBI lookup), reads fail to decode — silently, in some cases — even though the user already supplied the correct reference via `-f/--fasta`.

### Fix

Pass the user-supplied reference to `pysam.AlignmentFile(..., reference_filename=...)` at the three sites that decode reads:

- `ATARVA/baseline.py` — `cooper()` (read-wise genotyping loop)
- `ATARVA/baseline.py` — `mini_cooper()` (loci-wise / amplicon / somatic loop)
- `ATARVA/genotype.py` — the tag-detection loop that iterates reads to pick the MD/cs/CIGAR processing path

`reference_filename` is ignored by pysam for BAM/SAM input, and `-f/--fasta` is always provided, so it is passed unconditionally. `b_check()` is left unchanged since it only reads the header (no decoding), which does not need the reference.

### Validation

Built a CRAM from the bundled `test_data` (`samtools view -C -T test_ref.fasta`) and ran `atarva genotype --format cram`. With the fix, CRAM decodes cleanly and produces genotypes identical to the BAM run:

```
chr4  HD_HTT    1|2 : AL 108,87 : CN 36,29
chrX  FXS_FMR1  1|2 : AL 95,98  : CN 31,32
```
